### PR TITLE
Make index field facetable

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ defaults: &defaults
     alert: 'Welcome to the W. Duke & Sons collection...</a>'
     # The blacklight configurations that should be applied to the controller for this collection.
     configure_blacklight:
-        add_facet_fields:
+        add_facet_field:
           - field: "Ddr::Index::Fields::ACTIVE_FEDORA_MODEL"
             label: Browse
             show: false
@@ -102,14 +102,18 @@ defaults: &defaults
             range:
                 num_segments: 6
                 segments: true
-        add_show_fields:
-          - field: "ActiveFedora::SolrService.solr_name(:title, :stored_searchable)"
+        add_show_field:
+          - field:
+              - :title
+              - :stored_searchable
             separator: "; "
             label: "Title"
           - field: "Ddr::Index::Fields::IS_MEMBER_OF_COLLECTION"
             label: "Collection"
             helper_method: descendant_of
-          - field: "ActiveFedora::SolrService.solr_name(:series, :stored_searchable)"
+          - field:
+            - :series
+            - :stored_searchable
             separator: "; "
             label: "Card Series"
             link_to_search: "Ddr::Index::Fields::SERIES_FACET"

--- a/alexharris/portal_view_configs.yml
+++ b/alexharris/portal_view_configs.yml
@@ -13,7 +13,7 @@ defaults: &defaults
       max_download: 1200
     blog_posts: https://blogs.library.duke.edu/bitstreams/api/get_tag_posts/?tag_slug=alexharris
     configure_blacklight:
-        add_facet_fields:
+        add_facet_field:
           - field: "Ddr::Index::Fields::ACTIVE_FEDORA_MODEL"
             label: Browse
             show: false
@@ -21,18 +21,22 @@ defaults: &defaults
             label: Location
             limit: 5
             collapse: false
-        add_show_fields:
-          - field: "ActiveFedora::SolrService.solr_name(:title, :stored_searchable)"
+        add_show_field:
+          - field: "Ddr::Index::Fields::TITLE"
             separator: "; "
             label: "Title"
           - field: "Ddr::Index::Fields::PERMANENT_URL"
             label: "Permalink"
             helper_method: permalink
-          - field: "ActiveFedora::SolrService.solr_name(:date, :stored_searchable)"
+          - field:
+            - :date
+            - :stored_searchable
             separator: "; "
             label: "Date"
             helper_method: display_edtf_date
-          - field: "ActiveFedora::SolrService.solr_name(:creator, :stored_searchable)"
+          - field:
+            - :creator
+            - :stored_searchable
             separator: "; "
             label: "Creator"
           - field: "Ddr::Index::Fields::LOCAL_ID"
@@ -48,21 +52,31 @@ defaults: &defaults
             separator: "; "
             label: "Source Collection"
             helper_method: source_collection
-          - field: "ActiveFedora::SolrService.solr_name(:spatial, :stored_searchable)"
+          - field:
+            - :spatial
+            - :stored_searchable
             separator: "; "
             label: "Location"
             link_to_search: "Ddr::Index::Fields::SPATIAL_FACET"
-          - field: "ActiveFedora::SolrService.solr_name(:subject, :stored_searchable)"
+          - field:
+            - :subject
+            - :stored_searchable
             separator: "; "
             label: "Subject"
             link_to_search: "Ddr::Index::Fields::SUBJECT_FACET"
-          - field: "ActiveFedora::SolrService.solr_name(:format, :stored_searchable)"
+          - field:
+            - :format
+            - :stored_searchable
             separator: "; "
             label: "Format"
-          - field: "ActiveFedora::SolrService.solr_name(:type, :stored_searchable)"
+          - field:
+            - :type
+            - :stored_searchable
             separator: "; "
             label: "Type"
-          - field: "ActiveFedora::SolrService.solr_name(:provenance, :stored_searchable)"
+          - field:
+            - :provenance
+            - :stored_searchable
             separator: "; "
             label: "Provenance" 
 

--- a/blake/portal_view_configs.yml
+++ b/blake/portal_view_configs.yml
@@ -35,7 +35,7 @@ defaults: &defaults
         - mfb106
     blog_posts: https://blogs.library.duke.edu/bitstreams/api/get_tag_posts/?tag_slug=blake
     configure_blacklight:
-        add_facet_fields:
+        add_facet_field:
           - field: "Ddr::Index::Fields::ACTIVE_FEDORA_MODEL"
             label: Browse
             show: false
@@ -43,18 +43,22 @@ defaults: &defaults
             label: Subject
             limit: 5
             collapse: false
-        add_show_fields:
-          - field: "ActiveFedora::SolrService.solr_name(:title, :stored_searchable)"
+        add_show_field:
+          - field: "Ddr::Index::Fields::TITLE"
             separator: "; "
             label: "Title"
           - field: "Ddr::Index::Fields::PERMANENT_URL"
             label: "Permalink"
             helper_method: permalink
-          - field: "ActiveFedora::SolrService.solr_name(:date, :stored_searchable)"
+          - field:
+            - :date
+            - :stored_searchable
             separator: "; "
             label: "Date"
             helper_method: display_edtf_date
-          - field: "ActiveFedora::SolrService.solr_name(:creator, :stored_searchable)"
+          - field:
+            - :creator
+            - :stored_searchable
             separator: "; "
             label: "Creator"
           - field: "Ddr::Index::Fields::LOCAL_ID"
@@ -70,23 +74,35 @@ defaults: &defaults
             separator: "; "
             label: "Source Collection"
             helper_method: source_collection
-          - field: "ActiveFedora::SolrService.solr_name(:spatial, :stored_searchable)"
+          - field:
+            - :spatial
+            - :stored_searchable
             separator: "; "
             label: "Location"
-          - field: "ActiveFedora::SolrService.solr_name(:subject, :stored_searchable)"
+          - field:
+            - :subject
+            - :stored_searchable
             separator: "; "
             label: "Subject"
             link_to_search: "Ddr::Index::Fields::SUBJECT_FACET"
-          - field: "ActiveFedora::SolrService.solr_name(:extent, :stored_searchable)"
+          - field:
+            - :extent
+            - :stored_searchable
             separator: "; "
             label: "Extent"
-          - field: "ActiveFedora::SolrService.solr_name(:format, :stored_searchable)"
+          - field:
+            - :format
+            - :stored_searchable
             separator: "; "
             label: "Format"
-          - field: "ActiveFedora::SolrService.solr_name(:type, :stored_searchable)"
+          - field:
+            - :type
+            - :stored_searchable
             separator: "; "
             label: "Type"
-          - field: "ActiveFedora::SolrService.solr_name(:provenance, :stored_searchable)"
+          - field:
+            - :provenance
+            - :stored_searchable
             separator: "; "
             label: "Provenance" 
 

--- a/catalog/portal_doc_configs.yml
+++ b/catalog/portal_doc_configs.yml
@@ -1,0 +1,11 @@
+defaults: &defaults
+
+development:
+  <<: *defaults
+
+test:
+  <<: *defaults
+
+production:
+  <<: *defaults
+  

--- a/catalog/portal_view_configs.yml
+++ b/catalog/portal_view_configs.yml
@@ -1,0 +1,24 @@
+defaults: &defaults
+  configure_blacklight:
+      add_facet_field:
+        - field: "Ddr::Index::Fields::ADMIN_SET_FACET"
+          label: Collection Group
+          helper_method: admin_set_full_name
+          collapse: false
+          limit: 5
+        - field: "Ddr::Index::Fields::COLLECTION_FACET"
+          label: Collection
+          helper_method: collection_title
+          limit: 5
+        - field: "Ddr::Index::Fields::ACTIVE_FEDORA_MODEL"
+          label: Browse
+          show: false
+
+development:
+  <<: *defaults
+
+test:
+  <<: *defaults
+
+production:
+  <<: *defaults

--- a/digital_collections/portal_view_configs.yml
+++ b/digital_collections/portal_view_configs.yml
@@ -3,7 +3,7 @@ defaults: &defaults
         admin_sets:
             - dc
     configure_blacklight:
-        add_facet_fields:
+        add_facet_field:
           - field: "Ddr::Index::Fields::COLLECTION_FACET"
             label: 'Collection'
             helper_method: 'collection_title'

--- a/hmp/portal_view_configs.yml
+++ b/hmp/portal_view_configs.yml
@@ -40,7 +40,7 @@ defaults: &defaults
         - hmpgp23472
     blog_posts: https://blogs.library.duke.edu/bitstreams/api/get_tag_posts/?tag_slug=hmp
     configure_blacklight:
-        add_facet_fields:
+        add_facet_field:
           - field: "Ddr::Index::Fields::ACTIVE_FEDORA_MODEL"
             label: Browse
             show: false
@@ -48,24 +48,32 @@ defaults: &defaults
             label: Subject
             limit: 5
             collapse: false
-        add_show_fields:
-          - field: "ActiveFedora::SolrService.solr_name(:title, :stored_searchable)"
+        add_show_field:
+          - field: "Ddr::Index::Fields::TITLE"
             separator: "; "
             label: "Title"
-          - field: "ActiveFedora::SolrService.solr_name(:description, :stored_searchable)"
+          - field:
+            - :description
+            - :stored_searchable
             separator: "; "
             label: "Description"
-          - field: "ActiveFedora::SolrService.solr_name(:print_number, :stored_searchable)"
+          - field:
+            - :print_number
+            - :stored_searchable
             separator: "; "
             label: "Print Number"
           - field: "Ddr::Index::Fields::PERMANENT_URL"
             label: "Permalink"
             helper_method: permalink
-          - field: "ActiveFedora::SolrService.solr_name(:date, :stored_searchable)"
+          - field:
+            - :date
+            - :stored_searchable
             separator: "; "
             label: "Date"
             helper_method: display_edtf_date
-          - field: "ActiveFedora::SolrService.solr_name(:creator, :stored_searchable)"
+          - field:
+            - :creator
+            - :stored_searchable
             separator: "; "
             label: "Creator"
           - field: "Ddr::Index::Fields::LOCAL_ID"
@@ -81,20 +89,30 @@ defaults: &defaults
             separator: "; "
             label: "Source Collection"
             helper_method: source_collection
-          - field: "ActiveFedora::SolrService.solr_name(:spatial, :stored_searchable)"
+          - field:
+            - :spatial
+            - :stored_searchable
             separator: "; "
             label: "Location"
-          - field: "ActiveFedora::SolrService.solr_name(:subject, :stored_searchable)"
+          - field:
+            - :subject
+            - :stored_searchable
             separator: "; "
             label: "Subject"
             link_to_search: "Ddr::Index::Fields::SUBJECT_FACET"
-          - field: "ActiveFedora::SolrService.solr_name(:format, :stored_searchable)"
+          - field:
+            - :format
+            - :stored_searchable
             separator: "; "
             label: "Format"
-          - field: "ActiveFedora::SolrService.solr_name(:type, :stored_searchable)"
+          - field:
+            - :type
+            - :stored_searchable
             separator: "; "
             label: "Type"
-          - field: "ActiveFedora::SolrService.solr_name(:provenance, :stored_searchable)"
+          - field:
+            - :provenance
+            - :stored_searchable
             separator: "; "
             label: "Provenance" 
 

--- a/rushbenjaminandjulia/portal_view_configs.yml
+++ b/rushbenjaminandjulia/portal_view_configs.yml
@@ -14,7 +14,7 @@ defaults: &defaults
       layout: portrait
     blog_posts: https://blogs.library.duke.edu/bitstreams/api/get_tag_posts/?tag_slug=rushbenjaminandjulia
     configure_blacklight:
-        add_facet_fields:
+        add_facet_field:
           - field: "Ddr::Index::Fields::ACTIVE_FEDORA_MODEL"
             label: Browse
             show: false
@@ -43,25 +43,33 @@ defaults: &defaults
           - field: "Ddr::Index::Fields::SPATIAL_FACET"
             label: Location
             limit: 5
-        add_show_fields:
-          - field: "ActiveFedora::SolrService.solr_name(:title, :stored_searchable)"
+        add_show_field:
+          - field: "Ddr::Index::Fields::TITLE"
             separator: "; "
             label: "Title"
-          - field: "ActiveFedora::SolrService.solr_name(:description, :stored_searchable)"
+          - field:
+            - :description
+            - :stored_searchable
             separator: "; "
             label: "Description"
           - field: "Ddr::Index::Fields::PERMANENT_URL"
             label: "Permalink"
             helper_method: permalink
-          - field: "ActiveFedora::SolrService.solr_name(:date, :stored_searchable)"
+          - field:
+            - :date
+            - :stored_searchable
             separator: "; "
             label: "Date"
             helper_method: display_edtf_date
-          - field: "ActiveFedora::SolrService.solr_name(:creator, :stored_searchable)"
+          - field:
+            - :creator
+            - :stored_searchable
             separator: "; "
             label: "Author"
             link_to_search: "Ddr::Index::Fields::CREATOR_FACET"
-          - field: "ActiveFedora::SolrService.solr_name(:contributor, :stored_searchable)"
+          - field:
+            - :contributor
+            - :stored_searchable
             separator: "; "
             label: "Recipient"
             link_to_search: "Ddr::Index::Fields::CONTRIBUTOR_FACET"
@@ -78,32 +86,48 @@ defaults: &defaults
             separator: "; "
             label: "Source Collection"
             helper_method: source_collection
-          - field: "ActiveFedora::SolrService.solr_name(:series, :stored_searchable)"
+          - field:
+            - :series
+            - :stored_searchable
             separator: "; "
             label: "Series"
             link_to_search: "Ddr::Index::Fields::SERIES_FACET"
-          - field: "ActiveFedora::SolrService.solr_name(:language, :stored_searchable)"
+          - field:
+            - :language
+            - :stored_searchable
             separator: "; "
             label: "Language"
             helper_method: language_display
-          - field: "ActiveFedora::SolrService.solr_name(:extent, :stored_searchable)"
+          - field:
+            - :extent
+            - :stored_searchable
             separator: "; "
             label: "Extent"
-          - field: "ActiveFedora::SolrService.solr_name(:spatial, :stored_searchable)"
+          - field:
+            - :spatial
+            - :stored_searchable
             separator: "; "
             label: "Location"
             link_to_search: "Ddr::Index::Fields::SPATIAL_FACET"
-          - field: "ActiveFedora::SolrService.solr_name(:subject, :stored_searchable)"
+          - field:
+            - :subject
+            - :stored_searchable
             separator: "; "
             label: "Subject"
             link_to_search: "Ddr::Index::Fields::SUBJECT_FACET"
-          - field: "ActiveFedora::SolrService.solr_name(:format, :stored_searchable)"
+          - field:
+            - :format
+            - :stored_searchable
             separator: "; "
             label: "Format"
-          - field: "ActiveFedora::SolrService.solr_name(:type, :stored_searchable)"
+          - field:
+            - :type
+            - :stored_searchable
             separator: "; "
             label: "Type"
-          - field: "ActiveFedora::SolrService.solr_name(:provenance, :stored_searchable)"
+          - field:
+            - :provenance
+            - :stored_searchable
             separator: "; "
             label: "Provenance" 
 development:

--- a/wdukesons/portal_view_configs.yml
+++ b/wdukesons/portal_view_configs.yml
@@ -75,7 +75,7 @@ defaults: &defaults
     blog_posts: https://blogs.library.duke.edu/bitstreams/api/get_tag_posts/?tag_slug=wdukesons
     alert: 'Welcome to the W. Duke & Sons collection - the first to appear in the next-generation platform we’re developing for Duke Digital Collections. <a href="http://blogs.library.duke.edu/bitstreams/2015/10/22/today-is-the-new-future-tripod3/">More about the project &raquo;</a>'
     configure_blacklight:
-        add_facet_fields:
+        add_facet_field:
           - field: "Ddr::Index::Fields::ACTIVE_FEDORA_MODEL"
             label: Browse
             show: false
@@ -103,11 +103,13 @@ defaults: &defaults
             label: Box Number
             limit: 5
             sort: index
-        add_show_fields:
-          - field: "ActiveFedora::SolrService.solr_name(:title, :stored_searchable)"
+        add_show_field:
+          - field: "Ddr::Index::Fields::TITLE"
             separator: "; "
             label: "Title"
-          - field: "ActiveFedora::SolrService.solr_name(:description, :stored_searchable)"
+          - field:
+            - :description
+            - :stored_searchable
             separator: "; "
             label: "Description"
           - field: "Ddr::Index::Fields::PERMANENT_URL"
@@ -119,27 +121,39 @@ defaults: &defaults
           - field: "Ddr::Index::Fields::IS_MEMBER_OF_COLLECTION"
             label: "Digital Collection"
             helper_method: descendant_of
-          - field: "ActiveFedora::SolrService.solr_name(:series, :stored_searchable)"
+          - field:
+            - :series
+            - :stored_searchable
             separator: "; "
             label: "Card Series"
             link_to_search: "Ddr::Index::Fields::SERIES_FACET"
-          - field: "ActiveFedora::SolrService.solr_name(:type, :stored_searchable)"
+          - field:
+            - :type
+            - :stored_searchable
             separator: "; "
             label: "Type"
             link_to_search: "Ddr::Index::Fields::TYPE_FACET"
-          - field: "ActiveFedora::SolrService.solr_name(:spatial, :stored_searchable)"
+          - field:
+            - :spatial
+            - :stored_searchable
             separator: "; "
             label: "Location"
             link_to_search: "Ddr::Index::Fields::SPATIAL_FACET"
-          - field: "ActiveFedora::SolrService.solr_name(:publisher, :stored_searchable)"
+          - field:
+            - :publisher
+            - :stored_searchable
             separator: "; "
             label: "Publisher"
             link_to_search: "Ddr::Index::Fields::PUBLISHER_FACET"
-          - field: "ActiveFedora::SolrService.solr_name(:date, :stored_searchable)"
+          - field:
+            - :date
+            - :stored_searchable
             separator: "; "
             label: "Year"
             helper_method: year_ranges
-          - field: "ActiveFedora::SolrService.solr_name(:language, :stored_searchable)"
+          - field:
+            - :language
+            - :stored_searchable
             separator: "; "
             label: "Language"
             helper_method: language_display
@@ -150,10 +164,14 @@ defaults: &defaults
             separator: "; "
             label: "Source Collection"
             helper_method: source_collection
-          - field: "ActiveFedora::SolrService.solr_name(:box_number, :stored_searchable)"
+          - field:
+            - :box_number
+            - :stored_searchable
             separator: "; "
             label: "Box Number"
-          - field: "ActiveFedora::SolrService.solr_name(:extent, :stored_searchable)"
+          - field:
+            - :extent
+            - :stored_searchable
             separator: "; "
             label: "Extent"
 development:


### PR DESCRIPTION
This branch includes updates to support changes to the index-field-config branch of ddr-public.
- add_show_fields is now add_show_field (singular) and add_facet_fields is now add_facet_field (singular) to match the Blacklight method names.
- There is a change to how solr fields are specified:

`- field: "ActiveFedora::SolrService.solr_name(:title, :stored_searchable)"`

is now:

```
- field:
  - :title
  - :stored_searchable
```
