### PR TITLE
Adjust configs to accept a custom thumbnail

### DIFF
--- a/alexharris/portal_doc_configs.yml
+++ b/alexharris/portal_doc_configs.yml
@@ -4,7 +4,8 @@ defaults: &defaults
             controller: digital_collections
             collection: alexharris
             item_id_field: local_id
-            thumbnail_image: "ahpst001024"
+            thumbnail_image:
+                local_id: "ahpst001024"
 
 development:
   <<: *defaults

--- a/blake/portal_doc_configs.yml
+++ b/blake/portal_doc_configs.yml
@@ -4,7 +4,8 @@ defaults: &defaults
             controller: digital_collections
             collection: blake
             item_id_field: local_id
-            thumbnail_image: "mfb001"
+            thumbnail_image:
+                local_id: "mfb001"
 development:
   <<: *defaults
 

--- a/hmp/portal_doc_configs.yml
+++ b/hmp/portal_doc_configs.yml
@@ -4,7 +4,8 @@ defaults: &defaults
             controller: digital_collections
             collection: hmp
             item_id_field: local_id
-            thumbnail_image: "hmpgp12314"
+            thumbnail_image:
+                local_id: "hmpgp12314"
 
 development:
   <<: *defaults

--- a/rushbenjaminandjulia/portal_doc_configs.yml
+++ b/rushbenjaminandjulia/portal_doc_configs.yml
@@ -4,7 +4,8 @@ defaults: &defaults
             controller: digital_collections
             collection: rushbenjaminandjulia
             item_id_field: local_id
-            thumbnail_image: "brpst008001"
+            thumbnail_image:
+                local_id: "brpst008001"
 
 development:
   <<: *defaults

--- a/wdukesons/portal_doc_configs.yml
+++ b/wdukesons/portal_doc_configs.yml
@@ -4,7 +4,8 @@ defaults: &defaults
             controller: digital_collections
             collection: wdukesons
             item_id_field: local_id
-            thumbnail_image: "dscsi03005"
+            thumbnail_image:
+                local_id: "dscsi03005"
 
 development:
   <<: *defaults


### PR DESCRIPTION
Use custom_image instead of local_id to assign an image stored in ddr-portals asset directory.
